### PR TITLE
add a config for user vivification

### DIFF
--- a/clients/ruby/config.rb
+++ b/clients/ruby/config.rb
@@ -1,0 +1,5 @@
+module Pandarus
+  module Config
+    self.exclude_user_vivify = true
+  end
+end

--- a/clients/ruby/lib/pandarus/model_base.rb
+++ b/clients/ruby/lib/pandarus/model_base.rb
@@ -34,7 +34,7 @@ module Pandarus
     def vivify(constant_name, value)
       klass = begin
         # Try Ruby built-in constants first
-        constant_name.constantize
+        constant_name.constantize unless (Pandarus::Config.exclude_user_vivify && (constant_name == 'User'))
       rescue NameError
         # Pandarus models second
         "Pandarus::#{constant_name}".constantize


### PR DESCRIPTION
Sometimes a client User model for an app won't contain all the attributes that Pandarus sends. This config would allow for not vivifying the User model.
