### PR TITLE
Edit sections

### DIFF
--- a/api/sections.json
+++ b/api/sections.json
@@ -185,6 +185,46 @@
               "type": "string",
               "format": null,
               "required": true
+            },
+            {
+              "paramType": "form",
+              "name": "course_section[name]",
+              "description": "The name of the section",
+              "type": "string",
+              "format": null,
+              "required": false
+            },
+            {
+              "paramType": "form",
+              "name": "course_section[sis_section_id]",
+              "description": "The sis ID of the section",
+              "type": "string",
+              "format": null,
+              "required": false
+            },
+            {
+              "paramType": "form",
+              "name": "course_section[start_at]",
+              "description": "Section start date in ISO8601 format, e.g. 2011-01-01T01:00Z",
+              "type": "datetime",
+              "format": null,
+              "required": false
+            },
+            {
+              "paramType": "form",
+              "name": "course_section[end_at]",
+              "description": "Section end date in ISO8601 format. e.g. 2011-01-01T01:00Z",
+              "type": "datetime",
+              "format": null,
+              "required": false
+            },
+            {
+              "paramType": "form",
+              "name": "course_section[restrict_enrollments_to_section_dates]",
+              "description": "Set to true to restrict user enrollments to the start and end dates of the section.",
+              "type": "boolean",
+              "format": null,
+              "required": false
             }
           ],
           "type": "Section"


### PR DESCRIPTION
I was wrong about where the change needed to be made.  This allows editing of sections via pandarus.  In particular this lets you set and sis_section_id for manually created sections.  In my case I do this to manage teacher created sections enrollment via sis package uploads.